### PR TITLE
Address some compatibility adaptations

### DIFF
--- a/data/datasets/visual_genome.py
+++ b/data/datasets/visual_genome.py
@@ -58,15 +58,17 @@ class VisualGenomeTrainData:
         Load data in detectron format
         """
         fileName = "tmp/visual_genome_{}_data_{}{}{}{}{}.pkl".format(self.split, 'masks' if self.mask_exists else '', '_oi' if 'oi' in self.mask_location else '', "_clamped" if self.clamped else "", "_precomp" if self.precompute else "", "_clipped" if self.clipped else "")
-        print("Loading file: ", fileName)
         if os.path.isfile(fileName):
             #If data has been processed earlier, load that to save time
+            print("loading cached file: ", fileName)
             with open(fileName, 'rb') as inputFile:
                 dataset_dicts = pickle.load(inputFile)
         else:
             #Process data
             os.makedirs('tmp', exist_ok=True)
             dataset_dicts = self._process_data()
+            #TODO: this can cause problems, if it is excecuted in a distributed setup
+            print("creating cache file: ", fileName)
             with open(fileName, 'wb') as inputFile:
                 pickle.dump(dataset_dicts, inputFile)
         return dataset_dicts

--- a/engine/sg_trainer.py
+++ b/engine/sg_trainer.py
@@ -265,7 +265,7 @@ class SceneGraphSegmentationTrainer(DefaultTrainer):
         """
         If you want to do something with the data, you can wrap the dataloader.
         """
-        data = next(self._data_loader_iter)
+        data = next(self._trainer._data_loader_iter)
         mask_data = next(self.mask_train_loader)
         data_time = time.perf_counter() - start
 
@@ -292,10 +292,7 @@ class SceneGraphSegmentationTrainer(DefaultTrainer):
         with torch.cuda.stream(
             torch.cuda.Stream()
         ) if losses.device.type == "cuda" else _nullcontext():
-            metrics_dict = loss_dict
-            metrics_dict["data_time"] = data_time
-            self._write_metrics(metrics_dict)
-            self._detect_anomaly(losses, loss_dict)
+            self._trainer._write_metrics(loss_dict, data_time)
 
         """
         If you need gradient clipping/scaling or other processing, you can
@@ -365,7 +362,7 @@ class TestTrainer(SceneGraphTrainer):
             """
             If you want to do something with the data, you can wrap the dataloader.
             """
-            data = next(self._data_loader_iter)
+            data = next(self._trainer._data_loader_iter)
             data_time = time.perf_counter() - start
 
             """
@@ -397,10 +394,7 @@ class TestTrainer(SceneGraphTrainer):
             with torch.cuda.stream(
                 torch.cuda.Stream()
             ) if losses.device.type == "cuda" else _nullcontext():
-                metrics_dict = loss_dict
-                metrics_dict["data_time"] = data_time
-                self._write_metrics(metrics_dict)
-                self._detect_anomaly(losses, loss_dict)
+                self._trainer._write_metrics(loss_dict, data_time)
 
             """
             If you need gradient clipping/scaling or other processing, you can

--- a/scripts/train_SG_segmentation_head.py
+++ b/scripts/train_SG_segmentation_head.py
@@ -27,7 +27,7 @@ def register_coco_data(args):
     MetadataCatalog.get('coco_train_2014').set(thing_classes=classes, evaluator_type='coco')
     annotations = args.DATASETS.MSCOCO.ANNOTATIONS
     dataroot = args.DATASETS.MSCOCO.DATAROOT
-    register_coco_instances("coco_train_2017", {}, annotations + 'instances_train2017_clipped.json', dataroot + '/train2017/')
+    register_coco_instances("coco_train_2017", {}, annotations + 'instances_train2017.json', dataroot + '/train2017/')
     register_coco_instances("coco_val_2017", {}, annotations + 'instances_val2017.json', dataroot + '/val2017/')
 
 def setup(args):


### PR DESCRIPTION
Adapt sg_trainer code for detectron2; remove '_clipped' postfix'; add more explicit print statements for dataset caching

Addresses issues https://github.com/ubc-vision/segmentation-sg/issues/8 and https://github.com/ubc-vision/segmentation-sg/issues/7